### PR TITLE
readline stream treated as a TTY (tty = true) in node 17+. Had to pre…

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ var defaultStream = function () {
     var stream = require('readline').createInterface(process.stdin, process.stdout, completer, true);
     stream.print = function (msg) {
         console.log(msg);
+        stream.resume()
     };
     var self = this;
     var oldInsertString = stream._insertString;
@@ -208,6 +209,7 @@ Cli.prototype.ask = function (str, mask, fn) {
         fn = mask;
         mask = null;
     }
+
     stream.setPrompt(str);
     this.mask = mask;
     if (this.mask != undefined) {


### PR DESCRIPTION
…ss keys twice in order for them to show up in the prompt. It looks like the ReadStream was pausing. So I just resume it after printing to the console